### PR TITLE
QF-1347 Add family name to print exceptions list

### DIFF
--- a/src/SFA.DAS.Assessor.Functions.UnitTests/Print/PrintExtensionFunction/StringNameCaseExtensionTests.cs
+++ b/src/SFA.DAS.Assessor.Functions.UnitTests/Print/PrintExtensionFunction/StringNameCaseExtensionTests.cs
@@ -16,6 +16,7 @@ namespace SFA.DAS.Assessor.Functions.UnitTests.Print.PrintExtensionFunction
         [TestCase("MacHajewski", "Machajewski")]
         [TestCase("MacIazek", "Maciazek")]
         [TestCase("MacHniak", "Machniak")]
+        [TestCase("MacEdo", "Macedo")]
         public void ThenFamilyNameShouldBeCapitalizedCorrectly(string familyName, string expectedToProperCase)
         {
             // Arrange

--- a/src/SFA.DAS.Assessor.Functions/Domain/Print/Extensions/StringNameCaseExtension.cs
+++ b/src/SFA.DAS.Assessor.Functions/Domain/Print/Extensions/StringNameCaseExtension.cs
@@ -59,6 +59,7 @@ namespace SFA.DAS.Assessor.Functions.Domain.Print.Extensions
             MacMcFamilyNameExceptions.Add(@"\bMacHajewski", "Machajewski");
             MacMcFamilyNameExceptions.Add(@"\bMacIazek", "Maciazek");
             MacMcFamilyNameExceptions.Add(@"\bMacHniak", "Machniak");
+            MacMcFamilyNameExceptions.Add(@"\bMacEdo", "Macedo");
 
             NonEnglishFamilyNameReplacements.Add(@"\bAl(?=\s+\w)", "al");               // al Arabic or forename Al.
             NonEnglishFamilyNameReplacements.Add(@"\b(Bin|Binti|Binte)\b", "bin");      // bin, binti, binte Arabic


### PR DESCRIPTION
I have added a new family name to the certificate print exceptions list and I have added the family name to the unit test test cases list. 